### PR TITLE
Added choice to use dot-notation in parameters.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -164,6 +164,28 @@ var AppGenerator = yeoman.generators.Base.extend({
         fs.writeFileSync(appKernelPath, newAppKernelContents);
     },
 
+    updateParametersDist: function() {
+        if(this.useParameterDotNotation) {
+          // update parameters.yml.dist
+          var parametersDistPath = 'app/config/parameters.yml.dist';
+          var parametersDistContents = this.readFileAsString(parametersDistPath);
+
+          var newparametersDistContents = parametersDistContents.replace(/(database|mailer)_(.*):/g, '$1.$2:');
+
+          fs.unlinkSync(parametersDistPath);
+          fs.writeFileSync(parametersDistPath, newparametersDistContents);
+
+          // update config.yml
+          var configPath = 'app/config/config.yml';
+          var configContent = this.readFileAsString(configPath);
+
+          var newconfigContent = configContent.replace(/%(database|mailer)_(.*)%/g, '%$1.$2%');
+
+          fs.unlinkSync(configPath);
+          fs.writeFileSync(configPath, newconfigContent);
+        }
+    },
+
     updateView: function () {
         var cb = this.async();
 
@@ -345,6 +367,11 @@ module.exports = AppGenerator.extend({
             message: 'Commit (commit/branch/tag)',
             default: this.symfonyDefaults.commit,
             when: symfonyCustom
+        }, {
+            type: 'confirm',
+            name: 'useParameterDotNotation',
+            message: 'Would you like to use the dot notation in your parameters file for database and mailer options?',
+            default: false
         }, /* {
          type: 'confirm',
          name: 'symfonyAcme',
@@ -398,6 +425,7 @@ module.exports = AppGenerator.extend({
 
             // set symfony repository and demoBundle option
             this.setSymfonyDistribution(props);
+            this.useParameterDotNotation = props.useParameterDotNotation;
 
             var useFramework = _.partial(has, 'framework');
             this.noFramework = useFramework('noframework');
@@ -544,6 +572,7 @@ module.exports = AppGenerator.extend({
         this.cleanConfig();
         this.updateController();
         this.updateAppKernel();
+        this.updateParametersDist();
         this.updateView();
 
 


### PR DESCRIPTION
Added choice for dot notation for database_ and mailer_ parameter

This is helpful if you want to be able to define these options via environment variable.
More about that: http://symfony.com/doc/current/cookbook/configuration/external_parameters.html
