### PR TITLE
#197 CriticalJS produces useless css

### DIFF
--- a/app/templates/grunt/critical.js
+++ b/app/templates/grunt/critical.js
@@ -4,7 +4,7 @@
  */
 module.exports = {
     options: {
-        base: '<%%= paths.dist %>',
+        base: '.tmp',
         minify: true,
         css: ['.tmp/styles/main.css']
     },


### PR DESCRIPTION
https://github.com/bezoerb/generator-grunt-symfony/issues/197

Turns out it does infact require that the index.html have valid paths for it's css. the 'base' option sets the base for routing these paths. As the .tmp folder is in the root, not the dist folder, this is most appropriate and fixes the issue.
