### PR TITLE
system-polyfills give 404 on karma:unit

### DIFF
--- a/app/templates/test/jspm/karma.conf.js
+++ b/app/templates/test/jspm/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = function(config) {
             // Edit this to your needs
             config: 'app/Resources/public/scripts/config.js',
             loadFiles: ['tests/Frontend/**/*Spec.js'],
-            serveFiles : ['app/Resources/public/scripts/**/*.js'],
+            serveFiles : ['app/Resources/public/scripts/**/*.js', 'jspm_packages/**/*.js'],
             paths: {
                 '*': 'base/app/Resources/public/scripts/*',
                 'tests\/*': 'base/tests/*',


### PR DESCRIPTION
`19 08 2016 10:27:29.062:WARN [web-server]: 404: /base/jspm_packages/system-polyfills.js`

Karma jspm_packages root scripts were unreachable. system-polyfills.js installs to the root of jspm_packages and would result in a 404.
