### PR TITLE
Serving from app fails on sub dirs

### DIFF
--- a/app/templates/scripts/jspm/modules/service-worker.js
+++ b/app/templates/scripts/jspm/modules/service-worker.js
@@ -29,7 +29,7 @@ export function init() {
 
     debug('initializing service worker');
     if ('serviceWorker' in navigator && (window.location.protocol === 'https:' || isLocalhost)) {
-        navigator.serviceWorker.register('service-worker.js')
+        navigator.serviceWorker.register('/service-worker.js')
             .then(function (registration) {
                 debug('service worker registration', registration);
 


### PR DESCRIPTION
This line ignores the SystemJS root in the config.js, as such setting to root here. Otherwise will 404 on subdirs when using grunt serve.
